### PR TITLE
Swap the posistion of leader and follower

### DIFF
--- a/TougePlugin/TougeSession.cs
+++ b/TougePlugin/TougeSession.cs
@@ -63,11 +63,17 @@ public class TougeSession
             {
                 // If the result of the first two races is a tie, race until there is a winner.
                 // Sudden death style.
+                bool isChallengerLeading = true; // Challenger as leader at first.
                 while (result.Outcome == RaceOutcome.Tie)
                 {
-                    // Keep racing, and stop when there is a winner of disconnect.
-                    Race race = _raceFactory(Challenger, Challenged);
+                    // Swap the posistion of leader and follower.
+                    EntryCar leader = isChallengerLeading ? Challenger : Challenged;
+                    EntryCar follower = isChallengerLeading ? Challenged : Challenger;
+
+                    Race race = _raceFactory(leader, follower);
                     result = await race.RaceAsync();
+
+                    isChallengerLeading = !isChallengerLeading;
                 }
 
                 if (result.Outcome != RaceOutcome.Disconnected)


### PR DESCRIPTION
After the first two races, if they remain tied, the leader and follower should continually swap their starting positions in the upcoming races to ensure fairness.
I re-submitted the PR because there were some typos in the previous commit. Sorry for any inconvenience this may have caused.